### PR TITLE
dev(feat): add proxy support

### DIFF
--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -62,9 +62,7 @@ def _get_proxy(proxy: str | None = None, proxy_type: str = "https") -> str | Non
     return proxy or _get_system_proxy(proxy_type)
 
 
-def _get_proxies_for_requests(
-    proxy: str | None = None, proxy_type: str = "https"
-):
+def _get_proxies_for_requests(proxy: str | None = None, proxy_type: str = "https"):
     """
     Load proxy to dict-formatted proxies for `requests` module.
     """

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -7,17 +7,19 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.request
 from base64 import urlsafe_b64encode
 from hashlib import sha256
 from random import uniform
 from secrets import token_urlsafe
 from time import sleep
-from typing import Any, cast
+from typing import Any, cast, Optional
 from urllib.parse import urlencode
 
 import pyderman
 import requests
 from selenium import webdriver
+from selenium.common import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
@@ -42,6 +44,32 @@ REQUESTS_KWARGS: dict[str, Any] = {
 }
 
 
+def _get_system_proxy(proxy_type: str = 'https') -> Optional[str]:
+    """
+    Load proxy from system, such as `export ALL_PROXY=xxxx` in ~/.bashrc.
+    """
+    _sys_proxies = urllib.request.getproxies()
+    if 'all' in _sys_proxies:
+        return _sys_proxies['all']
+    else:
+        return _sys_proxies.get(proxy_type, None)
+
+
+def _get_proxy(proxy: Optional[str] = None, proxy_type: str = 'https') -> Optional[str]:
+    """
+    If `proxy` is given, just use this one, otherwise load proxy from system.
+    """
+    return proxy or _get_system_proxy(proxy_type)
+
+
+def _get_proxies_for_requests(proxy: Optional[str] = None, proxy_type: str = 'https') -> Optional[dict]:
+    """
+    Load proxy to dict-formatted proxies for `requests` module.
+    """
+    _proxy = _get_proxy(proxy, proxy_type)
+    return {'all': _proxy} if _proxy else None
+
+
 class GetPixivToken:
     def __init__(self) -> None:
 
@@ -55,23 +83,22 @@ class GetPixivToken:
         headless: bool | None = False,
         user: str | None = None,
         pass_: str | None = None,
+        proxy: str | None = None,
     ) -> LoginInfo:
         self.headless, self.user, self.pass_ = headless, user, pass_
         executable_path = pyderman.install(verbose=False, browser=pyderman.chrome)
         if type(executable_path) is not str:
             raise ValueError("Executable path is not str somehow.")
         if headless is not None and headless:
-            opts = self.__get_headless_option()
-            self.driver = webdriver.Chrome(
-                executable_path=executable_path,
-                options=opts,
-                desired_capabilities=self.caps,
-            )
-
+            opts = self.__get_headless_option(proxy)
         else:
-            self.driver = webdriver.Chrome(
-                executable_path=executable_path, desired_capabilities=self.caps
-            )
+            opts = self.__get_option(proxy)
+
+        self.driver = webdriver.Chrome(
+            executable_path=executable_path,
+            options=opts,
+            desired_capabilities=self.caps
+        )
 
         code_verifier, code_challenge = self.__oauth_pkce()
         login_params = {
@@ -110,13 +137,14 @@ class GetPixivToken:
                 "app-os-version": "14.6",
                 "app-os": "ios",
             },
+            proxies=_get_proxies_for_requests(proxy, 'https'),
             **REQUESTS_KWARGS,
         )
 
         return cast(LoginInfo, response.json())
 
     @staticmethod
-    def refresh(refresh_token: str) -> LoginInfo:
+    def refresh(refresh_token: str, proxy: Optional[str] = None) -> LoginInfo:
         response = requests.post(
             AUTH_TOKEN_URL,
             data={
@@ -131,6 +159,7 @@ class GetPixivToken:
                 "app-os-version": "14.6",
                 "app-os": "ios",
             },
+            proxies=_get_proxies_for_requests(proxy, 'https'),
             **REQUESTS_KWARGS,
         )
         return cast(LoginInfo, response.json())
@@ -152,12 +181,28 @@ class GetPixivToken:
             elm.send_keys(character)
             sleep(uniform(0.3, 0.7))
 
+    # For the users in different language areas, this text will be different,
+    # so using `Login` directly may cause `NoSuchElementException`.
+    # The code here may also need to be supplemented with versions in other languages.
+    __LOGIN_TEXTS__ = ['Login', '登录']
+
     def __try_login(self) -> None:
         if self.headless:
-            el = self.driver.find_element(
-                By.XPATH, "//button[@type='submit'][contains(text(), 'Login')]"
-            )
-            el.send_keys(Keys.ENTER)
+            el, lerr = None, None
+            for login_text in self.__LOGIN_TEXTS__:
+                try:
+                    el = self.driver.find_element(
+                        By.XPATH, f"//button[@type='submit'][contains(text(), {login_text!r})]"
+                    )
+                except NoSuchElementException as err:
+                    lerr = err
+                else:
+                    break
+
+            if el:
+                el.send_keys(Keys.ENTER)
+            else:
+                raise lerr
 
         WebDriverWait(self.driver, 60).until_not(
             EC.presence_of_element_located((By.CLASS_NAME, "busy-container")),
@@ -176,7 +221,16 @@ class GetPixivToken:
             )
 
     @staticmethod
-    def __get_headless_option() -> webdriver.chrome.options.Options:
+    def __get_option(proxy: Optional[str] = None) -> webdriver.chrome.options.Options:
+        options = webdriver.ChromeOptions()
+        proxy = _get_proxy(proxy)
+        if proxy:
+            options.add_argument(f'--proxy-server={proxy}')
+
+        return options
+
+    @staticmethod
+    def __get_headless_option(proxy: Optional[str] = None) -> webdriver.chrome.options.Options:
         options = webdriver.ChromeOptions()
         options.add_argument("--headless")
         options.add_argument("--disable-gpu")
@@ -184,12 +238,18 @@ class GetPixivToken:
         options.add_argument("--disable-infobars")
         options.add_argument("--disable-dev-shm-usage")
         options.add_argument("--disable-browser-side-navigation")
-        options.add_argument('--proxy-server="direct://"')
-        options.add_argument("--proxy-bypass-list=*")
         options.add_argument("--start-maximized")
         options.add_argument("--no-sandbox")
         options.add_argument("--disable-dev-shm-usage")
         options.add_argument("--user-agent=" + USER_AGENT)
+
+        proxy = _get_proxy(proxy)
+        if proxy:
+            options.add_argument(f'--proxy-server={proxy}')
+        else:
+            options.add_argument('--proxy-server="direct://"')
+            options.add_argument("--proxy-bypass-list=*")
+
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
         options.add_experimental_option("useAutomationExtension", False)
         return options

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -13,7 +13,7 @@ from hashlib import sha256
 from random import uniform
 from secrets import token_urlsafe
 from time import sleep
-from typing import Any, cast, Optional
+from typing import Any, Optional, cast
 from urllib.parse import urlencode
 
 import pyderman
@@ -44,30 +44,32 @@ REQUESTS_KWARGS: dict[str, Any] = {
 }
 
 
-def _get_system_proxy(proxy_type: str = 'https') -> Optional[str]:
+def _get_system_proxy(proxy_type: str = "https") -> str | None:
     """
     Load proxy from system, such as `export ALL_PROXY=xxxx` in ~/.bashrc.
     """
     _sys_proxies = urllib.request.getproxies()
-    if 'all' in _sys_proxies:
-        return _sys_proxies['all']
+    if "all" in _sys_proxies:
+        return _sys_proxies["all"]
     else:
         return _sys_proxies.get(proxy_type, None)
 
 
-def _get_proxy(proxy: Optional[str] = None, proxy_type: str = 'https') -> Optional[str]:
+def _get_proxy(proxy: str | None = None, proxy_type: str = "https") -> str | None:
     """
     If `proxy` is given, just use this one, otherwise load proxy from system.
     """
     return proxy or _get_system_proxy(proxy_type)
 
 
-def _get_proxies_for_requests(proxy: Optional[str] = None, proxy_type: str = 'https') -> Optional[dict]:
+def _get_proxies_for_requests(
+    proxy: str | None = None, proxy_type: str = "https"
+) -> dict | None:
     """
     Load proxy to dict-formatted proxies for `requests` module.
     """
     _proxy = _get_proxy(proxy, proxy_type)
-    return {'all': _proxy} if _proxy else None
+    return {"all": _proxy} if _proxy else None
 
 
 class GetPixivToken:
@@ -97,7 +99,7 @@ class GetPixivToken:
         self.driver = webdriver.Chrome(
             executable_path=executable_path,
             options=opts,
-            desired_capabilities=self.caps
+            desired_capabilities=self.caps,
         )
 
         code_verifier, code_challenge = self.__oauth_pkce()
@@ -137,14 +139,14 @@ class GetPixivToken:
                 "app-os-version": "14.6",
                 "app-os": "ios",
             },
-            proxies=_get_proxies_for_requests(proxy, 'https'),
+            proxies=_get_proxies_for_requests(proxy, "https"),
             **REQUESTS_KWARGS,
         )
 
         return cast(LoginInfo, response.json())
 
     @staticmethod
-    def refresh(refresh_token: str, proxy: Optional[str] = None) -> LoginInfo:
+    def refresh(refresh_token: str, proxy: str | None = None) -> LoginInfo:
         response = requests.post(
             AUTH_TOKEN_URL,
             data={
@@ -159,7 +161,7 @@ class GetPixivToken:
                 "app-os-version": "14.6",
                 "app-os": "ios",
             },
-            proxies=_get_proxies_for_requests(proxy, 'https'),
+            proxies=_get_proxies_for_requests(proxy, "https"),
             **REQUESTS_KWARGS,
         )
         return cast(LoginInfo, response.json())
@@ -184,7 +186,7 @@ class GetPixivToken:
     # For the users in different language areas, this text will be different,
     # so using `Login` directly may cause `NoSuchElementException`.
     # The code here may also need to be supplemented with versions in other languages.
-    __LOGIN_TEXTS__ = ['Login', '登录']
+    __LOGIN_TEXTS__ = ["Login", "登录"]
 
     def __try_login(self) -> None:
         if self.headless:
@@ -192,7 +194,8 @@ class GetPixivToken:
             for login_text in self.__LOGIN_TEXTS__:
                 try:
                     el = self.driver.find_element(
-                        By.XPATH, f"//button[@type='submit'][contains(text(), {login_text!r})]"
+                        By.XPATH,
+                        f"//button[@type='submit'][contains(text(), {login_text!r})]",
                     )
                 except NoSuchElementException as err:
                     lerr = err
@@ -221,16 +224,18 @@ class GetPixivToken:
             )
 
     @staticmethod
-    def __get_option(proxy: Optional[str] = None) -> webdriver.chrome.options.Options:
+    def __get_option(proxy: str | None = None) -> webdriver.chrome.options.Options:
         options = webdriver.ChromeOptions()
         proxy = _get_proxy(proxy)
         if proxy:
-            options.add_argument(f'--proxy-server={proxy}')
+            options.add_argument(f"--proxy-server={proxy}")
 
         return options
 
     @staticmethod
-    def __get_headless_option(proxy: Optional[str] = None) -> webdriver.chrome.options.Options:
+    def __get_headless_option(
+        proxy: str | None = None,
+    ) -> webdriver.chrome.options.Options:
         options = webdriver.ChromeOptions()
         options.add_argument("--headless")
         options.add_argument("--disable-gpu")
@@ -245,7 +250,7 @@ class GetPixivToken:
 
         proxy = _get_proxy(proxy)
         if proxy:
-            options.add_argument(f'--proxy-server={proxy}')
+            options.add_argument(f"--proxy-server={proxy}")
         else:
             options.add_argument('--proxy-server="direct://"')
             options.add_argument("--proxy-bypass-list=*")

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -23,6 +23,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -62,7 +63,7 @@ def _get_proxy(proxy: str | None = None, proxy_type: str = "https") -> str | Non
     return proxy or _get_system_proxy(proxy_type)
 
 
-def _get_proxies_for_requests(proxy: str | None = None, proxy_type: str = "https"):
+def _get_proxies_for_requests(proxy: str | None = None, proxy_type: str = "https") -> dict[str, str] | None:
     """
     Load proxy to dict-formatted proxies for `requests` module.
     """
@@ -202,8 +203,10 @@ class GetPixivToken:
 
             if isinstance(lerr, NoSuchElementException):
                 raise lerr
-            else:
+            elif isinstance(el, WebElement):
                 el.send_keys(Keys.ENTER)
+            else:
+                assert False, 'Should not reach here!'
 
         WebDriverWait(self.driver, 60).until_not(
             EC.presence_of_element_located((By.CLASS_NAME, "busy-container")),

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -201,10 +201,10 @@ class GetPixivToken:
                 else:
                     break
 
-            if isinstance(lerr, NoSuchElementException):
-                raise lerr
-            elif isinstance(el, WebElement):
+            if isinstance(el, WebElement):
                 el.send_keys(Keys.ENTER)
+            elif isinstance(lerr, NoSuchElementException):
+                raise lerr
             else:
                 assert False, 'Should not reach here!'
 

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -13,13 +13,13 @@ from hashlib import sha256
 from random import uniform
 from secrets import token_urlsafe
 from time import sleep
-from typing import Any, Optional, cast
+from typing import Any, cast
 from urllib.parse import urlencode
 
 import pyderman
 import requests
 from selenium import webdriver
-from selenium.common import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
@@ -64,7 +64,7 @@ def _get_proxy(proxy: str | None = None, proxy_type: str = "https") -> str | Non
 
 def _get_proxies_for_requests(
     proxy: str | None = None, proxy_type: str = "https"
-) -> dict | None:
+):
     """
     Load proxy to dict-formatted proxies for `requests` module.
     """
@@ -202,10 +202,10 @@ class GetPixivToken:
                 else:
                     break
 
-            if el:
-                el.send_keys(Keys.ENTER)
-            else:
+            if isinstance(lerr, NoSuchElementException):
                 raise lerr
+            else:
+                el.send_keys(Keys.ENTER)
 
         WebDriverWait(self.driver, 60).until_not(
             EC.presence_of_element_located((By.CLASS_NAME, "busy-container")),


### PR DESCRIPTION
In this PR, I added the following content:
* System-level proxy (such as `export ALL_PROXY=xxx` in ~/.bashrc), if there is, start chrome with this proxy
* User-defined proxy, if the user specifies, use this proxy to start chrome
* Multi-language recognition support for login buttons (the original code only recognizes the button whose text is `Login`, so it runs incorrectly in other languages)

The following tests were performed (in Mainland China):
* Use system-level proxy (socks5 protocol), run `gppt login`, it works normally
* Use system-level proxy, run `gppt login-headless`, it works normally
* Use system-level proxy, run through Library, try to get refresh_token and refresh access_token, it works normally
* Use a custom agent, run through Library, try to get refresh_token and refresh access_token, it works normally