### PR TITLE
In order not to be detected that chromedriver is controlling the browser

### DIFF
--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -186,17 +186,17 @@ class GetPixivToken:
 
         if headless:
             options.add_argument("--headless")
-            options.add_argument("--disable-gpu")
-            options.add_argument("--disable-extensions")
-            options.add_argument("--disable-infobars")
-            options.add_argument("--disable-dev-shm-usage")
-            options.add_argument("--disable-browser-side-navigation")
-            options.add_argument("--start-maximized")
-            options.add_argument("--no-sandbox")
-            options.add_argument("--disable-dev-shm-usage")
-            options.add_argument("--user-agent=" + USER_AGENT)
-            options.add_experimental_option("excludeSwitches", ["enable-automation"])
-            options.add_experimental_option("useAutomationExtension", False)
+        options.add_argument("--disable-gpu")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--disable-infobars")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--disable-browser-side-navigation")
+        options.add_argument("--start-maximized")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--user-agent=" + USER_AGENT)
+        options.add_experimental_option("excludeSwitches", ["enable-automation"])
+        options.add_experimental_option("useAutomationExtension", False)
 
         if "all" in PROXIES:
             options.add_argument(f"--proxy-server={PROXIES['all']}")


### PR DESCRIPTION
In order not to be detected that chromedriver is controlling the browser when headless is set to False.