### PR TITLE
Fix TypeError due to executable_path deprecation since Selenium 4.10.0

### DIFF
--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -21,10 +21,10 @@ import pyderman
 import requests
 from selenium import webdriver
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC  # noqa: N812
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.chrome.service import Service
 
 from .login_response_types import LoginInfo
 
@@ -47,10 +47,6 @@ OptionsType = webdriver.chrome.options.Options
 
 
 class GetPixivToken:
-    def __init__(self) -> None:
-        self.caps = DesiredCapabilities.CHROME.copy()
-        self.caps["goog:loggingPrefs"] = {"performance": "ALL"}  # enable performance logs
-
     def login(
         self,
         *,
@@ -72,10 +68,10 @@ class GetPixivToken:
 
             executable_path = installed_executable_path
 
+        webdriver_service = Service(executable_path=executable_path)
         self.driver = webdriver.Chrome(
-            executable_path=executable_path,
-            options=self.__get_chrome_option(headless),
-            desired_capabilities=self.caps,
+            service=webdriver_service,
+            options=self.__get_chrome_option(headless)
         )
 
         code_verifier, code_challenge = self.__oauth_pkce()
@@ -193,6 +189,7 @@ class GetPixivToken:
         options.add_argument("--user-agent=" + USER_AGENT)
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
         options.add_experimental_option("useAutomationExtension", False)  # noqa: FBT003
+        options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
 
         if "all" in PROXIES:
             options.add_argument(f"--proxy-server={PROXIES['all']}")

--- a/gppt/_selenium.py
+++ b/gppt/_selenium.py
@@ -20,11 +20,11 @@ from urllib.request import getproxies
 import pyderman
 import requests
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC  # noqa: N812
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.chrome.service import Service
 
 from .login_response_types import LoginInfo
 
@@ -69,10 +69,7 @@ class GetPixivToken:
             executable_path = installed_executable_path
 
         webdriver_service = Service(executable_path=executable_path)
-        self.driver = webdriver.Chrome(
-            service=webdriver_service,
-            options=self.__get_chrome_option(headless)
-        )
+        self.driver = webdriver.Chrome(service=webdriver_service, options=self.__get_chrome_option(headless))
 
         code_verifier, code_challenge = self.__oauth_pkce()
         login_params = {
@@ -189,7 +186,7 @@ class GetPixivToken:
         options.add_argument("--user-agent=" + USER_AGENT)
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
         options.add_experimental_option("useAutomationExtension", False)  # noqa: FBT003
-        options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
+        options.set_capability("goog:loggingPrefs", {"performance": "ALL"})
 
         if "all" in PROXIES:
             options.add_argument(f"--proxy-server={PROXIES['all']}")


### PR DESCRIPTION
Trying to login using the library currently results in this error:
```python
Traceback (most recent call last):
  File "/home/ex/projects/twitter-to-pixiv-migration-v2/test.py", line 208, in <module>
    res = g.login(headless=True, username=PIXIV_EMAIL, password=PIXIV_PASSWORD)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ex/projects/twitter-to-pixiv-migration-v2/venv/lib/python3.11/site-packages/gppt/_selenium.py", line 75, in login
    self.driver = webdriver.Chrome(
                  ^^^^^^^^^^^^^^^^^
TypeError: WebDriver.__init__() got an unexpected keyword argument 'executable_path'
```

As often stated in Selenium logs before until the release of the 4.10.0 version, this is due to the deprecation of the `executable_path` parameter used in the `get-pixivpy-token/gppt/_selenium.py` file. The solution is to use a Service object instead.  

The problem occurred due to lack of attention to the deprecation warnings, but also because a bot is constantly updating the dependencies and releases are being made without any test beforehand. I highly suggest interrupting the use of these bots or at least to introduce some testing methodology.